### PR TITLE
Added first version of laser filters

### DIFF
--- a/depth_laser_filter/CMakeLists.txt
+++ b/depth_laser_filter/CMakeLists.txt
@@ -3,7 +3,7 @@ project(depth_laser_filter)
 
 set(THIS_PACKAGE_ROS_DEPS sensor_msgs roscpp tf filters message_filters laser_geometry pluginlib angles)
 
-find_package(catkin REQUIRED COMPONENTS ${THIS_PACKAGE_ROS_DEPS})
+find_package(catkin REQUIRED COMPONENTS ${THIS_PACKAGE_ROS_DEPS} roslaunch)
 find_package(Boost REQUIRED COMPONENTS system signals)
 include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
@@ -13,8 +13,14 @@ catkin_package(
   DEPENDS
 )
 
+roslaunch_add_file_check(launch)
+
 add_executable(max_range_filter_node src/depth_filter_node.cpp)
 target_link_libraries(max_range_filter_node ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_executable(single_readings_filter_node src/single_readings_filter_node.cpp)
 target_link_libraries(single_readings_filter_node ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
+install(DIRECTORY launch
+	DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+

--- a/depth_laser_filter/CMakeLists.txt
+++ b/depth_laser_filter/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(depth_laser_filter)
+
+set(THIS_PACKAGE_ROS_DEPS sensor_msgs roscpp tf filters message_filters laser_geometry pluginlib angles)
+
+find_package(catkin REQUIRED COMPONENTS ${THIS_PACKAGE_ROS_DEPS})
+find_package(Boost REQUIRED COMPONENTS system signals)
+include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+
+
+catkin_package(
+  CATKIN_DEPENDS ${THIS_PACKAGE_ROS_DEPS}
+  DEPENDS
+)
+
+add_executable(max_range_filter_node src/depth_filter_node.cpp)
+target_link_libraries(max_range_filter_node ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
+add_executable(single_readings_filter_node src/single_readings_filter_node.cpp)
+target_link_libraries(single_readings_filter_node ${catkin_LIBRARIES} ${Boost_LIBRARIES})

--- a/depth_laser_filter/launch/laser_scan_filter.launch
+++ b/depth_laser_filter/launch/laser_scan_filter.launch
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<launch>
+	<node pkg="depth_laser_filter" type="max_range_filter_node" respawn="false" name="depth_laser_filter">
+		<param name="min_th" value="0.6"/>
+		<param name="laser_topic_in" value="scan_depth"/>
+		<param name="laser_topic_out" value="scan_depth_filter"/>
+	</node>
+</launch>

--- a/depth_laser_filter/launch/single_reading_filter.launch
+++ b/depth_laser_filter/launch/single_reading_filter.launch
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<launch>
+	<node pkg="depth_laser_filter" type="single_readings_filter_node" respawn="false" name="single_reading_scan_filter">
+		<param name="min_th" value="0.6"/>
+		<param name="laser_topic_in" value="scan"/>
+		<param name="laser_topic_out" value="scan_single_filter"/>
+	</node>
+</launch>

--- a/depth_laser_filter/package.xml
+++ b/depth_laser_filter/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="jrcapriles@gmail.com">Jose Capriles</maintainer>
   <author email="jrcapriles@gmail.com">Jose Capriles</author>
   
-  <license>TODO</license>
+  <license>MIT</license>
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>angles</build_depend>

--- a/depth_laser_filter/package.xml
+++ b/depth_laser_filter/package.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<package>
+  <name>depth_laser_filter</name>
+  <version>0.0.0</version>
+  <description>The depth_filter package</description>
+
+  <maintainer email="jrcapriles@gmail.com">Jose Capriles</maintainer>
+  <author email="jrcapriles@gmail.com">Jose Capriles</author>
+  
+  <license>TODO</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>angles</build_depend>
+  <build_depend>message_filters</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>filters</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>tf</build_depend>
+  <build_depend>laser_geometry</build_depend>
+  <build_depend>pluginlib</build_depend>
+  <run_depend>angles</run_depend>
+  <run_depend>message_filters</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>filters</run_depend>
+  <run_depend>sensor_msgs</run_depend>
+  <run_depend>tf</run_depend>
+  <run_depend>laser_geometry</run_depend>
+  <run_depend>pluginlib</run_depend>
+
+  <export>
+  </export>
+
+</package>

--- a/depth_laser_filter/src/depth_filter_node.cpp
+++ b/depth_laser_filter/src/depth_filter_node.cpp
@@ -1,0 +1,74 @@
+#include "ros/ros.h"
+#include "sensor_msgs/LaserScan.h"
+#include "message_filters/subscriber.h"
+#include "tf/message_filter.h"
+#include "tf/transform_listener.h"
+#include "filters/filter_chain.h"
+
+class GenericLaserScanFilterNode
+{
+protected:
+  // Our NodeHandle
+  ros::NodeHandle nh_;
+
+  // Components for tf::MessageFilter
+  tf::TransformListener tf_;
+  message_filters::Subscriber<sensor_msgs::LaserScan> scan_sub_;
+
+  // Components for publishing
+  sensor_msgs::LaserScan msg_;
+  ros::Publisher output_pub_;
+
+  ros::Timer deprecation_timer_;
+
+  double min_th_;
+
+
+public:
+  // Constructor
+  GenericLaserScanFilterNode() :
+    scan_sub_(nh_, "scan_depth", 50), 
+    min_th_(0.6)
+  {
+    scan_sub_.registerCallback(boost::bind(&GenericLaserScanFilterNode::callback, this, _1));
+    
+    // Advertise output
+    output_pub_ = nh_.advertise<sensor_msgs::LaserScan>("scan_depth_cleaner", 1000);
+  }
+  
+  // Callback
+  void callback(const sensor_msgs::LaserScan::ConstPtr& msg_in)
+  {
+    // Copy the incoming laser scan
+    msg_ = *msg_in;
+
+    // Iterate over the range readings and substitute nan or small readings with max range
+    for (unsigned int i = 0; i < msg_.ranges.size(); i++)
+    {
+	if( (msg_.ranges[i] <= min_th_) || (msg_.ranges[i] >  msg_.range_max) || (isnan(msg_.ranges[i])))
+	{
+	    msg_.ranges[i] = msg_.range_max;
+	}
+    }
+	                         
+    // Publish the output
+    output_pub_.publish(msg_);
+  }
+};
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "depth_scan_filter_node");
+  
+  GenericLaserScanFilterNode t;
+  ros::spin();
+  
+  return 0;
+}
+
+
+
+  
+
+
+

--- a/depth_laser_filter/src/single_readings_filter_node.cpp
+++ b/depth_laser_filter/src/single_readings_filter_node.cpp
@@ -10,10 +10,13 @@ class GenericLaserScanFilterNode
 protected:
   // Our NodeHandle
   ros::NodeHandle nh_;
+  ros::NodeHandle private_nh_;
+
 
   // Components for tf::MessageFilter
   tf::TransformListener tf_;
-  message_filters::Subscriber<sensor_msgs::LaserScan> scan_sub_;
+  message_filters::Subscriber<sensor_msgs::LaserScan> *scan_sub_;
+
 
   // Components for publishing
   sensor_msgs::LaserScan msg_;
@@ -23,17 +26,27 @@ protected:
 
   double min_th_;
 
+  std::string sub_topic_;
+  std::string pub_topic_;
+
 
 public:
   // Constructor
-  GenericLaserScanFilterNode() :
-    scan_sub_(nh_, "scan_depth", 50), 
-    min_th_(0.6)
+  GenericLaserScanFilterNode():
+    private_nh_("~"),
+    min_th_(0.6), 
+    sub_topic_("scan"), 
+    pub_topic_("scan_filtered")
   {
-    scan_sub_.registerCallback(boost::bind(&GenericLaserScanFilterNode::callback, this, _1));
+    private_nh_.getParam("min_th", min_th_);
+    private_nh_.getParam("laser_topic_in", sub_topic_);
+    private_nh_.getParam("laser_topic_out", pub_topic_);
+    
+    scan_sub_ = new message_filters::Subscriber<sensor_msgs::LaserScan>(nh_, sub_topic_, 50);
+    scan_sub_->registerCallback(boost::bind(&GenericLaserScanFilterNode::callback, this, _1));
     
     // Advertise output
-    output_pub_ = nh_.advertise<sensor_msgs::LaserScan>("single_reading_scan_filtered", 1000);
+    output_pub_ = nh_.advertise<sensor_msgs::LaserScan>(pub_topic_, 100);
   }
   
   // Callback

--- a/depth_laser_filter/src/single_readings_filter_node.cpp
+++ b/depth_laser_filter/src/single_readings_filter_node.cpp
@@ -1,0 +1,77 @@
+#include "ros/ros.h"
+#include "sensor_msgs/LaserScan.h"
+#include "message_filters/subscriber.h"
+#include "tf/message_filter.h"
+#include "tf/transform_listener.h"
+#include "filters/filter_chain.h"
+
+class GenericLaserScanFilterNode
+{
+protected:
+  // Our NodeHandle
+  ros::NodeHandle nh_;
+
+  // Components for tf::MessageFilter
+  tf::TransformListener tf_;
+  message_filters::Subscriber<sensor_msgs::LaserScan> scan_sub_;
+
+  // Components for publishing
+  sensor_msgs::LaserScan msg_;
+  ros::Publisher output_pub_;
+
+  ros::Timer deprecation_timer_;
+
+  double min_th_;
+
+
+public:
+  // Constructor
+  GenericLaserScanFilterNode() :
+    scan_sub_(nh_, "scan_depth", 50), 
+    min_th_(0.6)
+  {
+    scan_sub_.registerCallback(boost::bind(&GenericLaserScanFilterNode::callback, this, _1));
+    
+    // Advertise output
+    output_pub_ = nh_.advertise<sensor_msgs::LaserScan>("single_reading_scan_filtered", 1000);
+  }
+  
+  // Callback
+  void callback(const sensor_msgs::LaserScan::ConstPtr& msg_in)
+  {
+    // Copy the incoming laser scan
+    msg_ = *msg_in;
+
+    // Iterate over the range readings and remove single readings
+    for (unsigned int i = 1; i < msg_.ranges.size()-1; i++)
+    {
+	// if previous and next value are nan or max range assing max range to the current range value
+        if( (isnan(msg_.ranges[i-1]) || (msg_.ranges[i-1] == msg_.range_max))  &&
+            (isnan(msg_.ranges[i+1]) || (msg_.ranges[i+1] == msg_.range_max)))
+	{
+	    msg_.ranges[i] = msg_.range_max;
+	}
+
+    }
+
+    // Publish the output
+    output_pub_.publish(msg_);
+  }
+};
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "single_readings_filter_node");
+  
+  GenericLaserScanFilterNode t;
+  ros::spin();
+  
+  return 0;
+}
+
+
+
+  
+
+
+


### PR DESCRIPTION
Adding the filtering package. There are two nodes:
- max_range_filter_node: this node iterates over the range readings replacing nan values for max_range. (Probably this will help clearing the costmap when there is no return from the laser)
- single_readings_filter_node: this node substitute single readings between two max_range or two nan values with max_range. 